### PR TITLE
updated message ordering to cover both localhost and heroku

### DIFF
--- a/app/views/meetings/_chat_room.html.erb
+++ b/app/views/meetings/_chat_room.html.erb
@@ -2,7 +2,7 @@
 <div class="chat-messaging-function">
   <div class="messages-wrapper messages">
     <% if chat_room.messages %>
-      <% chat_room.messages.reverse.each do |message| %>
+      <% chat_room.messages.order(:created_at).each do |message| %>
         <%= render partial: "messages/message", locals: { message: message, author: current_user == message.user }  %>
         <% end %>
       <% end %>


### PR DESCRIPTION
No actual functional changes to prod, just resolves an issue that localhost and heroku were each ordering messages in the opposite way 